### PR TITLE
analysis/det_sens: hack in oblateness correction if aephem not available

### DIFF
--- a/python/analysis/det_sens/planet_cal.py
+++ b/python/analysis/det_sens/planet_cal.py
@@ -8,16 +8,27 @@ from scipy.interpolate import InterpolatedUnivariateSpline as spline1d
 
 from . import blackbody as BB
 
-# There will be something available.  Note, before you add pyephem,
-# that historically it's had a weird value for Uranus' radius.  So
-# check it.
+# The nice thing aephem has, and that other Python ephemeris packages
+# appear to lack, is an accounting for oblateness and sub-observer
+# latitude in the solid angle computation.  For Uranus, which has a
+# modest difference in equatorial and polar radius but a very odd spin
+# axis, this affects the solid angle at the 1-2% level.  pyephem
+# reports the projected equatorial radius, in degrees, and we need to
+# compute an additional correction factor to the naive pi*r**2 disk
+# solid angle computation.  In the case that aephem is not present, we
+# need to provide that correction somehow.
+
 ephem_modules = []
 try:
     import aephem
     ephem_modules.append('aephem')
 except ImportError:
     pass
-
+try:
+    import ephem
+    ephem_modules.append('ephem')
+except ImportError:
+    pass
 
 def get_planet_solid_angle(planet, ctime):
     """
@@ -37,6 +48,57 @@ def get_planet_solid_angle(planet, ctime):
         obj = aephem.p_orb[planet]
         phys = aephem.p_phys[planet]
         return aephem.disc_solid_angle(jd, obs, obj, phys)
+
+    if name == 'ephem':
+        act = moby2.ephem.ACTEphem()
+        single = np.asarray(ctime).ndim == 0
+        if single:
+            ctime = [ctime]
+        results = []
+        for t in ctime:
+            act.set_timestamp(t)
+            u = act.get_object(planet.capitalize())
+            r = u.radius
+            omega = np.pi * u.radius**2
+            results.append(omega)
+        # Corrections?
+        if planet in ['uranus', 'jupiter']:
+            efactor = solid_angle_correction(ctime, planet)
+            results = [om*e for om,e in zip(results, efactor)]
+        else:
+            raise RuntimeError("Solid angle correction factor not "
+                               "available for '%s'" % planet)
+        if single:
+            return results[0]
+        return np.array(results)
+
+
+def solid_angle_correction(t, target):
+    """Returns the approximate sub-observer latitude, in degrees, of
+    planetary target at ctime t (which can be an array or scalar).
+    The current model gets Uranus and Jupiter to <.1%; Saturn to ~.2%
+    (but you'd want to account for the rings anyway).
+
+    """
+    lims = [1356998400, 1893456000]
+    p = {
+        'uranus': [ 3.88233016e+00,  4.81513918e+01, -2.54042514e+00, -1.20158753e+00,
+                    -2.46918964e-04,  6.21477912e+00,
+                    1577836800, 0.047481307441877396],
+        'jupiter': [ 2.21912058e-02, -7.21533904e-02, -2.11716337e+00,  2.79381276e+00,
+                     1.40789074e-03,  5.36641642e-01,
+                     1577836800, 0.1435630105925818],
+        'saturn': [ 1.80574507e+00, -8.90907531e+00,  3.67589879e+01, -2.85961149e+01,
+                    1.55770490e-03,  1.65458760e-01,
+                    1577836800, 0.22899679859188238]
+    }[target]
+    t0, e = p[-2:]
+    m, b, A, B, omega_m, omega_b = p[:-2]
+    dt = (t - t0) / (86400*365.24)
+    assert np.all(lims[0] <= np.asarray(t)) and np.all(np.asarray(t) <= lims[1])
+    omega = omega_m * dt + omega_b
+    lat = dt*m + b + A*np.cos(omega*dt) + B*np.sin(omega*dt)
+    return (1. + np.sin(lat*np.pi/180)**2 * e)**-.5
 
 
 class BrightnessModel(object):


### PR DESCRIPTION
The reason aephem might not be available is that the Python bindings won't compile for Python 3.  We could probably work around this by creating our own binding(s) for the simple thing we need here -- the solid angle including oblateness of planet whatever.