### PR TITLE
Fix memory leaks

### DIFF
--- a/src/dirfile.c
+++ b/src/dirfile.c
@@ -489,6 +489,7 @@ static PyObject *dirfile_load_channels(PyObject *self, PyObject *args)
             any_errors = 1;
         }
     }
+    if (!conv.raw) free(buf);
     }
     
     Py_END_ALLOW_THREADS

--- a/src/filter.c
+++ b/src/filter.c
@@ -913,6 +913,7 @@ static PyObject *find_jumps(PyObject *self, PyObject *args)
             if (fabs(jump_j) > jump[i]) jump[i] = fabs(jump_j);
         }
     }
+    free(data);
     return jump_array;
 }
 


### PR DESCRIPTION
find_jumps leaks ~200 Mb per TOD. `data` needs to be freed.