### PR TITLE
Support building on python-3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "numpy",
+    # Astropy depends on numpy 1.x with python-3.9.  Place
+    # a build-time dependency here so that we build with a
+    # compatible version of numpy.  Remove this after dropping
+    # python-3.9 support.
+    "astropy",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "moby2"
+readme = "README.rst"
+description = "ACTpol support"
+urls = {source = "https://github.com/ACTCollaboration/moby2"}
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+dependencies = [
+    "future",
+    "numpy",
+    "scipy",
+    "astropy",
+    "matplotlib",
+    "ephem",
+    "pytz",
+]
+version = "0.1"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Topic :: Scientific/Engineering :: Astronomy",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]

--- a/python/tod/cuts.py
+++ b/python/tod/cuts.py
@@ -693,7 +693,7 @@ def fill_cuts(tod=None, cuts=None, data=None,
     for deti in det_list:
         mask = cuts.cuts[deti].get_mask()
         offset = cuts.sample_offset - si
-        total_mask = np.ones(nsamps, dtype=np.bool)
+        total_mask = np.ones(nsamps, dtype=bool)
         total_mask[max(0,offset):min(nsamps,cuts.nsamps+offset)] = \
             mask[max(0,-offset):min(nsamps-offset,cuts.nsamps)]
         cuts_list = CutsVector.from_mask(total_mask)

--- a/python/util/moby_fits.py
+++ b/python/util/moby_fits.py
@@ -41,6 +41,7 @@ numpy_to_fits = [
     (np.float64, 'D', None),
     # Hack for bools; store as byte.
     (np.bool_,    'B', None),
+    (bool,    'B', None),
 ]
 
 _numpy_to_fits = {

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 from __future__ import print_function
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
-VERSION = '0.1'
 
 import glob
 import sys
@@ -44,26 +43,24 @@ analysis_modules =  [
 if sys.version_info.major >= 3:
     analysis_modules.append('socompat')
 
-setup (name = 'moby2',
-       version = VERSION,
-       description = 'ACTpol support',
-       package_dir = {'moby2': 'python'},
-       ext_modules = [module1],
-       scripts = scripts,
-       packages = (
-           ['moby2',
-            'moby2.aux_data',
-            'moby2.detectors',
-            'moby2.ephem',
-            'moby2.instruments',
-            'moby2.instruments.actpol',
-            'moby2.instruments.mbac',
-            'moby2.mapping',
-            'moby2.pointing',
-            'moby2.scripting',
-            'moby2.tod',
-            'moby2.util',
-            'moby2.analysis'] +
-           ['moby2.analysis.%s' % p for p in analysis_modules]
-       )
-   )
+setup(name = 'moby2',
+    package_dir = {'moby2': 'python'},
+    ext_modules = [module1],
+    scripts = scripts,
+    packages = (
+        ['moby2',
+        'moby2.aux_data',
+        'moby2.detectors',
+        'moby2.ephem',
+        'moby2.instruments',
+        'moby2.instruments.actpol',
+        'moby2.instruments.mbac',
+        'moby2.mapping',
+        'moby2.pointing',
+        'moby2.scripting',
+        'moby2.tod',
+        'moby2.util',
+        'moby2.analysis'] +
+        ['moby2.analysis.%s' % p for p in analysis_modules]
+    )
+)

--- a/src/dirfile.c
+++ b/src/dirfile.c
@@ -40,9 +40,10 @@ int extract_float32_uint32(float *dest, uint32_t *src, long n,
 
 static PyTypeObject
 ptrobjType = {
-    PyObject_HEAD_INIT(NULL)
 #if PY_MAJOR_VERSION >= 3
+    PyVarObject_HEAD_INIT(NULL, 0)
 #else
+    PyObject_HEAD_INIT(NULL)
     0,                         /* ob_size */
 #endif
     "ptrobj",                  /* tp_name */


### PR DESCRIPTION
Loading ACT data is a requirement for the Simons Observatory, at least for the next few years.  This means that moby2 is a required piece of the SO software stack.  That in turn means that moby2 needs to be installable in modern python environments.  This PR makes several changes to support building with python-3.12.